### PR TITLE
Enable CI for website

### DIFF
--- a/otterdog/eclipse-epsilon.jsonnet
+++ b/otterdog/eclipse-epsilon.jsonnet
@@ -42,7 +42,7 @@ orgs.newOrg('eclipse-epsilon') {
       delete_branch_on_merge: false,
       web_commit_signoff_required: false,
       workflows+: {
-        enabled: false,
+        enabled: true,
       },
     },
   ],


### PR DESCRIPTION
We would like to run some Cypress end-to-end tests on the website, specifically around the Epsilon Playground which makes heavy use of JavaScript. We have created this script, which we would like to run from Github Actions when the `playground` folder changes:

https://github.com/eclipse-epsilon/epsilon-website/blob/main/mkdocs/docs/playground/run-cypress-local.sh